### PR TITLE
File size limit is 5TB with Drive client

### DIFF
--- a/doc_source/workdocs_drive_help.md
+++ b/doc_source/workdocs_drive_help.md
@@ -5,7 +5,7 @@ Amazon WorkDocs Drive enables you to open and work with Amazon WorkDocs files on
 **Note**  
 You must belong to a network domain in order to use Amazon WorkDocs Drive\. Also, your system administrator may assign a different drive letter\. If you're unsure about your network domain or drive letter, contact your administrator\.
 
-Amazon WorkDocs Drive is available for PC and macOS users, and for Workspaces on Windows\. Amazon WorkDocs Drive can upload and download files of up to 5 GB each, and allows file path lengths of up to 260 characters\.
+Amazon WorkDocs Drive is available for PC and macOS users, and for Workspaces on Windows\. Amazon WorkDocs Drive can upload and download files of up to 5 TB each, and allows file path lengths of up to 260 characters\.
 
 As you go, remember that Amazon WorkDocs Drive only creates links to your files\. It doesn't write copies to your hard drive\. For example, say you open a word processor file from Amazon WorkDocs Drive\. Editing that file changes the current version of the file in Amazon WorkDocs\. 
 


### PR DESCRIPTION
According to FAQ: https://aws.amazon.com/workdocs/faq/ (General section):

Q. What is the maximum file size that can be uploaded to WorkDocs?
Using the Drive client on Mac or PC, you can upload individual files up to 5TB in size. We recommend using the Drive client to transfer large files to WorkDocs.

The limit of 5GB is when using the web interface (I've tested and have error: "The file must not be larger than 5GB")

I've tested and be able to successfully transfer a 10GB file with the Mac Drive client.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
